### PR TITLE
fix: typo in emoji-response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.1] - 2018-11-04
+
+### Fixed
+
+- Fix typo in emoji-response for top list and most played when there is no result
+
 ## [1.0.0] - 2018-11-04
 
 Feels pretty solid and production worthy, let's bump it to 1.0.0! :tada:

--- a/src/adapters/Database.re
+++ b/src/adapters/Database.re
@@ -164,7 +164,7 @@ let mostPlayed = sendMessage => {
 
         (
           switch (Belt.Array.length(rows)) {
-          | 0 => "No plays :san_panda:"
+          | 0 => "No plays :sad_panda:"
           | _ =>
             "*Most played*\n"
             ++ (
@@ -214,7 +214,7 @@ let toplist = sendMessage => {
 
         (
           switch (Belt.Array.length(rows)) {
-          | 0 => "No plays :san_panda:"
+          | 0 => "No plays :sad_panda:"
           | _ =>
             "*Toplist*\n"
             ++ (


### PR DESCRIPTION
The source looks so good after the refactor!! 💯 

Found what I think was a typo for `:san_panda:` -> `:sad_panda:`