### PR TITLE
fix: handle special characters

### DIFF
--- a/__tests__/Decode_test.re
+++ b/__tests__/Decode_test.re
@@ -17,13 +17,14 @@ describe("Decode", () => {
   describe("eventPayload", () =>
     test("parses eventPayload", () => {
       let mockEvent = {
-        event: {
-          subtype: Bot,
-          user: Some("UXXXXXXX"),
-          command: Commands.Help,
-          channel: "AA12345678",
-          text: "",
-        },
+        event:
+          Some({
+            subtype: Bot,
+            user: Some("UXXXXXXX"),
+            command: Commands.Help,
+            channel: "AA12345678",
+            text: "",
+          }),
         eventType: EventCallback,
       };
       let mockPayload =

--- a/__tests__/SpotifyUtils_test.re
+++ b/__tests__/SpotifyUtils_test.re
@@ -61,4 +61,13 @@ describe("SpotifyUtils", () => {
       |> toEqual("spotify:user:believer:playlist:5DQzhEf0U4Lji5kvXnPYSy")
     );
   });
+
+  describe("#spotifySearchUrl", () =>
+    test("creates a search url that handles special characters", () =>
+      expect(spotifySearchUrl(~query="angels &amp; äirwaves", ()))
+      |> toEqual(
+           "https://api.spotify.com/v1/search?q=angels%20%26%20%C3%83%C2%A4irwaves&type=track&limit=5&market=SE",
+         )
+    )
+  );
 });

--- a/src/Decode.re
+++ b/src/Decode.re
@@ -24,7 +24,7 @@ type event = {
 };
 
 type eventPayload = {
-  event,
+  event: option(event),
   eventType,
 };
 
@@ -92,7 +92,7 @@ let eventPayload = json =>
       | "event_callback" => EventCallback
       | _ => UnknownEvent
       },
-    event: json |> field("event", event),
+    event: json |> optional(field("event", event)),
   };
 
 let action = json => Json.Decode.{value: json |> field("value", string)};

--- a/src/Routes.re
+++ b/src/Routes.re
@@ -17,8 +17,13 @@ let event =
         switch (eventType) {
         | UrlVerification => handleVerification(body)
         | EventCallback =>
-          Event.handleEventCallback(event);
-          Response.sendStatus(Ok);
+          switch (event) {
+          | Some(e) =>
+            Event.handleEventCallback(e);
+            Response.sendStatus(Ok);
+          | None => Response.sendStatus(BadRequest)
+          }
+
         | _ => Response.sendStatus(BadRequest)
         };
       | None => Response.sendStatus(BadRequest)

--- a/src/adapters/Spotify.re
+++ b/src/adapters/Spotify.re
@@ -117,10 +117,7 @@ let searchTrack = (query: string) =>
   Js.Promise.(
     getToken()
     |> then_(token => {
-         let url =
-           "https://api.spotify.com/v1/search?q="
-           ++ (query |> Js.Global.encodeURIComponent)
-           ++ "&type=track&limit=5&market=SE";
+         let url = SpotifyUtils.spotifySearchUrl(~query, ());
 
          Axios.makeConfigWithUrl(
            ~url,

--- a/src/utils/SpotifyUtils.re
+++ b/src/utils/SpotifyUtils.re
@@ -50,3 +50,33 @@ module Playlists = {
     playlist(~user="believer", ~id="445NQ4LkJFtBsHUOdr3LFI");
   let slowdance = playlist(~user="believer", ~id="5DQzhEf0U4Lji5kvXnPYSy");
 };
+
+type searchType =
+  | Album
+  | Artist
+  | Playlist
+  | Track;
+
+let spotifySearchUrl = (~query, ~limit=5, ~market="SE", ~searchType=Track, ()) => {
+  let q =
+    query
+    |> Js.String.replaceByRe([%re "/&amp;/g"], "&")
+    |> Js.Global.encodeURIComponent;
+
+  let sType =
+    switch (searchType) {
+    | Album => "album"
+    | Artist => "artist"
+    | Playlist => "playlist"
+    | Track => "track"
+    };
+
+  "https://api.spotify.com/v1/search?q="
+  ++ q
+  ++ "&type="
+  ++ sType
+  ++ "&limit="
+  ++ string_of_int(limit)
+  ++ "&market="
+  ++ market;
+};


### PR DESCRIPTION
Closes #24 

Slack actually sends `&amp;` and not an actual ampersand (&). In the process I made the search url more versatile to be able to handle different types of searches.

Also found a bug with the decoded `event` which is optional and fixed the handling of that.