### PR TITLE
fix: play and queue when empty queue

### DIFF
--- a/__tests__/Sonos_test.re
+++ b/__tests__/Sonos_test.re
@@ -6,17 +6,79 @@ describe("Sonos", () =>
     describe("#SonosDecode", () => {
       describe("#currentPlayingState", () => {
         test("stopped", () =>
-          expect(SonosDecode.currentPlayingState("stopped")) |> toEqual(Stopped)
+          expect(SonosDecode.currentPlayingState("stopped"))
+          |> toEqual(Stopped)
         );
 
         test("playing", () =>
-          expect(SonosDecode.currentPlayingState("playing")) |> toEqual(Playing)
+          expect(SonosDecode.currentPlayingState("playing"))
+          |> toEqual(Playing)
         );
 
         test("undefined", () =>
-          expect(SonosDecode.currentPlayingState("undefined")) |> toEqual(UnknownState)
+          expect(SonosDecode.currentPlayingState("undefined"))
+          |> toEqual(UnknownState)
         );
-      })
+      });
+
+      describe("currentTrackResponse", () => {
+        test("parse current queue without track data", () => {
+          let mockPayload =
+            {|{
+              "position": 0,
+              "duration": 0,
+              "queuePosition": 0,
+              "uri": null
+            }|}
+            |> Json.parseOrRaise;
+
+          let expected: Sonos.currentTrackResponse = {
+            album: None,
+            albumArtURI: "",
+            albumArtURL: "",
+            artist: "",
+            duration: 0.,
+            position: 0.,
+            queuePosition: 0.,
+            title: "",
+            uri: "",
+          };
+
+          expect(SonosDecode.currentTrackResponse(mockPayload))
+          |> toEqual(expected);
+        });
+
+        test("parse current queue with track data", () => {
+          let mockPayload =
+            {|{
+              "album": "Sempiternal",
+              "albumArtURI": "some-art-uri",
+              "albumArtURL": "some-art-url",
+              "artist": "Bring Me The Horizon",
+              "duration": 320,
+              "position": 1,
+              "queuePosition": 3,
+              "title": "Hospital for Souls",
+              "uri": "some-uri"
+            }|}
+            |> Json.parseOrRaise;
+
+          let expected: Sonos.currentTrackResponse = {
+            album: Some("Sempiternal"),
+            albumArtURI: "some-art-uri",
+            albumArtURL: "some-art-url",
+            artist: "Bring Me The Horizon",
+            duration: 320.,
+            position: 1.,
+            queuePosition: 3.,
+            title: "Hospital for Souls",
+            uri: "some-uri",
+          };
+
+          expect(SonosDecode.currentTrackResponse(mockPayload))
+          |> toEqual(expected);
+        });
+      });
     })
   )
 );

--- a/src/Event.re
+++ b/src/Event.re
@@ -43,6 +43,7 @@ let handleEventCallback = event => {
       | Help => sendMessage(Utils.help) |> ignore
       | MostPlayed => Database.mostPlayed(sendMessage)
       | NowPlaying => nowPlaying(sendMessage)
+      | Play => Player.play(sendMessage)
       | PlayTrack => Player.playTrackNumber(q, sendMessage)
       | SpotifyCopy(tracks) =>
         tracks->Belt.Array.forEach(track =>
@@ -72,7 +73,6 @@ let handleEventCallback = event => {
       | Mute => Player.mute(true)
       | Next => Player.next()
       | Pause => Player.pause()
-      | Play => Player.play()
       | Previous => Player.previous()
       | Unmute => Player.mute(false)
       | UnhandledCommand => ()

--- a/src/adapters/Sonos.re
+++ b/src/adapters/Sonos.re
@@ -61,16 +61,20 @@ module SonosDecode = {
     items: json |> field("items", array(currentQueue)),
   };
 
+  let getWithDefault = field => Belt.Option.getWithDefault(field, "");
+
   let currentTrackResponse = json => {
     album: json |> optional(field("album", string)),
-    albumArtURI: json |> field("albumArtURI", string),
-    albumArtURL: json |> field("albumArtURL", string),
-    artist: json |> field("artist", string),
+    albumArtURI:
+      getWithDefault(json |> optional(field("albumArtURI", string))),
+    albumArtURL:
+      getWithDefault(json |> optional(field("albumArtURL", string))),
+    artist: getWithDefault(json |> optional(field("artist", string))),
     duration: json |> field("duration", Json.Decode.float),
     position: json |> field("position", Json.Decode.float),
     queuePosition: json |> field("queuePosition", Json.Decode.float),
-    title: json |> field("title", string),
-    uri: json |> field("uri", string),
+    title: getWithDefault(json |> optional(field("title", string))),
+    uri: getWithDefault(json |> optional(field("uri", string))),
   };
 
   let currentPlayingState = currentState =>

--- a/src/services/Queue.re
+++ b/src/services/Queue.re
@@ -43,10 +43,13 @@ let asNext = (track, user, sendMessage) => {
   };
 
   Services.getCurrentTrack()
-  |> then_(({queuePosition}) =>
+  |> then_(({position, queuePosition}) =>
        device->queue(parsedTrack, int_of_float(queuePosition) + 1)
        |> then_(() =>
-            sendMessage("Your track will play right after the current")
+            switch (position, queuePosition) {
+            | (0., 0.) => sendMessage("Your track will play right now")
+            | _ => sendMessage("Your track will play right after the current")
+            }
           )
        |> catch(Utils.handleError("queueAsNext"))
      )

--- a/src/services/Services.re
+++ b/src/services/Services.re
@@ -5,12 +5,14 @@ device->setSpotifyRegion(regionEurope);
 
 let getCurrentTrack = () =>
   device->currentTrack()
-  |> then_(current => current |> SonosDecode.currentTrackResponse |> resolve)
+  |> then_(current => SonosDecode.currentTrackResponse(current)->resolve)
   |> catch(Utils.handleError("getCurrentTrack"));
 
 let getPlayingState = () =>
-  device->getCurrentState() 
-  |> then_(playState => playState |> SonosDecode.currentPlayingState |> resolve)
+  device->getCurrentState()
+  |> then_(playState =>
+       playState |> SonosDecode.currentPlayingState |> resolve
+     )
   |> catch(Utils.handleError("getPlayingState"));
 
 let nowPlaying = sendMessage =>


### PR DESCRIPTION
Closes #26 

* When running `play` with an empty queue, command would fail silently. This returns a message to the user that the queue is empty.

* Handle "queue as next" when the queue is empty. `node-sonos` returned a bunch of empty fields which made the decoder fail. This adds default values for those fields as well as separate messages when the track is queued as the first track and after another song. 