### PR TITLE
fix: invalid dates in database

### DIFF
--- a/__tests__/Database_test.re
+++ b/__tests__/Database_test.re
@@ -1,0 +1,12 @@
+open Jest;
+
+describe("Database", () =>
+  Expect.(
+    describe("#formatTimestamp", () =>
+      test("should format a timestamp", () =>
+        expect(Database.formatTimestamp(1544185210000.))
+        |> toEqual("2018-12-07")
+      )
+    )
+  )
+);

--- a/src/adapters/Database.re
+++ b/src/adapters/Database.re
@@ -24,7 +24,7 @@ module Decode = {
     id: json |> field("id", int),
     uri: json |> field("uri", string),
     userId: json |> field("user_id", string),
-    timestamp: float_of_int(json |> field("timestamp", int)),
+    timestamp: json |> field("timestamp", Json.Decode.float),
   };
 
   let toplistRow = json => {

--- a/src/utils/DateFns.re
+++ b/src/utils/DateFns.re
@@ -1,1 +1,1 @@
-[@bs.module "date-fns"] external format: (string, string) => string = "";
+[@bs.module "date-fns"] external format: (Js.Date.t, string) => string = "";


### PR DESCRIPTION
Closes #25

Dates were being converted to an invalid timestamp format and database had `int` for the column, this changes to `float` in and `float` out.