### PR TITLE
feat: add short commands for queue

### DIFF
--- a/__tests__/Commands_test.re
+++ b/__tests__/Commands_test.re
@@ -1,174 +1,182 @@
 open Jest;
 open Commands;
+open Expect;
 
-describe("Commands", () => {
-  open Expect;
+describe("parseCommand", () => {
+  test("removes user", () =>
+    expect(parseCommand("<@UD8UR2GGP> s doors end")) |> toEqual("s")
+  );
 
-  describe("parseCommand", () => {
-    test("removes user", () =>
-      expect(parseCommand("<@UD8UR2GGP> s doors end")) |> toEqual("s")
-    );
+  test("lower cases text", () =>
+    expect(parseCommand("Search WOOP")) |> toEqual("search")
+  );
 
-    test("lower cases text", () =>
-      expect(parseCommand("Search WOOP")) |> toEqual("search")
-    );
+  test("lower cases text", () =>
+    expect(parseCommand("<@UD8UR2GGP> volume")) |> toEqual("volume")
+  );
+});
 
-    test("lower cases text", () =>
-      expect(parseCommand("<@UD8UR2GGP> volume")) |> toEqual("volume")
-    );
-  });
-
-  describe("#decodeCommand", () => {
-    describe("SpotifyCopy", () =>
-      test("should add spotify copy and paste", () =>
-        expect(
-          decodeCommand(
-            "<https://open.spotify.com/track/2mPE346iPVnss0GoRgwGTK>\n<https://open.spotify.com/track/4LT7xQZgICM6FqUJkWI6aM>",
-          ),
-        )
-        |> toEqual(
-             SpotifyCopy([|
-               "spotify:track:2mPE346iPVnss0GoRgwGTK",
-               "spotify:track:4LT7xQZgICM6FqUJkWI6aM",
-             |]),
-           )
+describe("#decodeCommand", () => {
+  describe("SpotifyCopy", () =>
+    test("should add spotify copy and paste", () =>
+      expect(
+        decodeCommand(
+          "<https://open.spotify.com/track/2mPE346iPVnss0GoRgwGTK>\n<https://open.spotify.com/track/4LT7xQZgICM6FqUJkWI6aM>",
+        ),
       )
+      |> toEqual(
+           SpotifyCopy([|
+             "spotify:track:2mPE346iPVnss0GoRgwGTK",
+             "spotify:track:4LT7xQZgICM6FqUJkWI6aM",
+           |]),
+         )
+    )
+  );
+
+  describe("#Emoji", () => {
+    test(":thumbsup:", () =>
+      expect(decodeCommand(":thumbsup:")) |> toEqual(Emoji(ThumbsUp))
     );
 
-    describe("#Emoji", () => {
-      test(":thumbsup:", () =>
-        expect(decodeCommand(":thumbsup:")) |> toEqual(Emoji(ThumbsUp))
-      );
-
-      test(":thumbsdown:", () =>
-        expect(decodeCommand(":thumbsdown:")) |> toEqual(Emoji(ThumbsDown))
-      );
-
-      test(":+1:", () =>
-        expect(decodeCommand(":+1:")) |> toEqual(Emoji(ThumbsUp))
-      );
-
-      test(":-1:", () =>
-        expect(decodeCommand(":-1:")) |> toEqual(Emoji(ThumbsDown))
-      );
-
-      test(":santa:", () =>
-        expect(decodeCommand(":santa:")) |> toEqual(Emoji(Santa))
-      );
-    });
-
-    test("clear", () =>
-      expect(decodeCommand("clear")) |> toEqual(Clear)
+    test(":thumbsdown:", () =>
+      expect(decodeCommand(":thumbsdown:")) |> toEqual(Emoji(ThumbsDown))
     );
 
-    test("currentqueue", () =>
-      expect(decodeCommand("currentqueue")) |> toEqual(CurrentQueue)
+    test(":+1:", () =>
+      expect(decodeCommand(":+1:")) |> toEqual(Emoji(ThumbsUp))
     );
 
-    test("getqueue", () =>
-      expect(decodeCommand("getqueue")) |> toEqual(CurrentQueue)
+    test(":-1:", () =>
+      expect(decodeCommand(":-1:")) |> toEqual(Emoji(ThumbsDown))
     );
 
-    test("freebird", () =>
-      expect(decodeCommand("freebird")) |> toEqual(EasterEgg(FreeBird))
-    );
-
-    test("friday", () =>
-      expect(decodeCommand("friday")) |> toEqual(EasterEgg(Friday))
-    );
-
-    test("fullqueue", () =>
-      expect(decodeCommand("fullqueue")) |> toEqual(FullQueue)
-    );
-
-    test("classics", () =>
-      expect(decodeCommand("classics"))
-      |> toEqual(EasterEgg(IteamClassics))
-    );
-
-    test("shoreline", () =>
-      expect(decodeCommand("shoreline")) |> toEqual(EasterEgg(Shoreline))
-    );
-
-    test("slowdance", () =>
-      expect(decodeCommand("slowdance")) |> toEqual(EasterEgg(Slowdance))
-    );
-
-    test("tequila", () =>
-      expect(decodeCommand("tequila")) |> toEqual(EasterEgg(Tequila))
-    );
-
-    test("help", () =>
-      expect(decodeCommand("help")) |> toEqual(Help)
-    );
-
-    test("l (library short-hand)", () =>
-      expect(decodeCommand("l")) |> toEqual(Library)
-    );
-
-    test("library", () =>
-      expect(decodeCommand("library")) |> toEqual(Library)
-    );
-
-    test("mute", () =>
-      expect(decodeCommand("mute")) |> toEqual(Mute)
-    );
-
-    test("next", () =>
-      expect(decodeCommand("next")) |> toEqual(Next)
-    );
-
-    test("np (nowplaying short-hand)", () =>
-      expect(decodeCommand("np")) |> toEqual(NowPlaying)
-    );
-
-    test("nowplaying", () =>
-      expect(decodeCommand("nowplaying")) |> toEqual(NowPlaying)
-    );
-
-    test("pause", () =>
-      expect(decodeCommand("pause")) |> toEqual(Pause)
-    );
-
-    test("play", () =>
-      expect(decodeCommand("play")) |> toEqual(Play)
-    );
-
-    test("playtrack", () =>
-      expect(decodeCommand("playtrack")) |> toEqual(PlayTrack)
-    );
-
-    test("previous", () =>
-      expect(decodeCommand("previous")) |> toEqual(Previous)
-    );
-
-    test("q (queue short-hand)", () =>
-      expect(decodeCommand("q")) |> toEqual(Queue)
-    );
-
-    test("queue", () =>
-      expect(decodeCommand("queue")) |> toEqual(Queue)
-    );
-
-    test("s (search short-hand)", () =>
-      expect(decodeCommand("s")) |> toEqual(Search)
-    );
-
-    test("search", () =>
-      expect(decodeCommand("search")) |> toEqual(Search)
-    );
-
-    test("unmute", () =>
-      expect(decodeCommand("unmute")) |> toEqual(Unmute)
-    );
-
-    test("unknowncommand", () =>
-      expect(decodeCommand("unknowncommand"))
-      |> toEqual(UnknownCommand("unknowncommand"))
-    );
-
-    test("volume", () =>
-      expect(decodeCommand("volume")) |> toEqual(Volume)
+    test(":santa:", () =>
+      expect(decodeCommand(":santa:")) |> toEqual(Emoji(Santa))
     );
   });
+
+  test("clear", () =>
+    expect(decodeCommand("clear")) |> toEqual(Clear)
+  );
+
+  test("cq", () =>
+    expect(decodeCommand("cq")) |> toEqual(CurrentQueue)
+  );
+
+  test("currentqueue", () =>
+    expect(decodeCommand("currentqueue")) |> toEqual(CurrentQueue)
+  );
+
+  test("gq", () =>
+    expect(decodeCommand("gq")) |> toEqual(CurrentQueue)
+  );
+
+  test("getqueue", () =>
+    expect(decodeCommand("getqueue")) |> toEqual(CurrentQueue)
+  );
+
+  test("freebird", () =>
+    expect(decodeCommand("freebird")) |> toEqual(EasterEgg(FreeBird))
+  );
+
+  test("friday", () =>
+    expect(decodeCommand("friday")) |> toEqual(EasterEgg(Friday))
+  );
+
+  test("fq", () =>
+    expect(decodeCommand("fq")) |> toEqual(FullQueue)
+  );
+
+  test("fullqueue", () =>
+    expect(decodeCommand("fullqueue")) |> toEqual(FullQueue)
+  );
+
+  test("classics", () =>
+    expect(decodeCommand("classics")) |> toEqual(EasterEgg(IteamClassics))
+  );
+
+  test("shoreline", () =>
+    expect(decodeCommand("shoreline")) |> toEqual(EasterEgg(Shoreline))
+  );
+
+  test("slowdance", () =>
+    expect(decodeCommand("slowdance")) |> toEqual(EasterEgg(Slowdance))
+  );
+
+  test("tequila", () =>
+    expect(decodeCommand("tequila")) |> toEqual(EasterEgg(Tequila))
+  );
+
+  test("help", () =>
+    expect(decodeCommand("help")) |> toEqual(Help)
+  );
+
+  test("l (library short-hand)", () =>
+    expect(decodeCommand("l")) |> toEqual(Library)
+  );
+
+  test("library", () =>
+    expect(decodeCommand("library")) |> toEqual(Library)
+  );
+
+  test("mute", () =>
+    expect(decodeCommand("mute")) |> toEqual(Mute)
+  );
+
+  test("next", () =>
+    expect(decodeCommand("next")) |> toEqual(Next)
+  );
+
+  test("np (nowplaying short-hand)", () =>
+    expect(decodeCommand("np")) |> toEqual(NowPlaying)
+  );
+
+  test("nowplaying", () =>
+    expect(decodeCommand("nowplaying")) |> toEqual(NowPlaying)
+  );
+
+  test("pause", () =>
+    expect(decodeCommand("pause")) |> toEqual(Pause)
+  );
+
+  test("play", () =>
+    expect(decodeCommand("play")) |> toEqual(Play)
+  );
+
+  test("playtrack", () =>
+    expect(decodeCommand("playtrack")) |> toEqual(PlayTrack)
+  );
+
+  test("previous", () =>
+    expect(decodeCommand("previous")) |> toEqual(Previous)
+  );
+
+  test("q (queue short-hand)", () =>
+    expect(decodeCommand("q")) |> toEqual(Queue)
+  );
+
+  test("queue", () =>
+    expect(decodeCommand("queue")) |> toEqual(Queue)
+  );
+
+  test("s (search short-hand)", () =>
+    expect(decodeCommand("s")) |> toEqual(Search)
+  );
+
+  test("search", () =>
+    expect(decodeCommand("search")) |> toEqual(Search)
+  );
+
+  test("unmute", () =>
+    expect(decodeCommand("unmute")) |> toEqual(Unmute)
+  );
+
+  test("unknowncommand", () =>
+    expect(decodeCommand("unknowncommand"))
+    |> toEqual(UnknownCommand("unknowncommand"))
+  );
+
+  test("volume", () =>
+    expect(decodeCommand("volume")) |> toEqual(Volume)
+  );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,7 +178,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -524,7 +524,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1096,7 +1096,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -1858,7 +1858,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -3626,7 +3626,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -3945,7 +3945,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
@@ -4154,7 +4154,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -4319,7 +4319,7 @@
     },
     "named-placeholders": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
       "integrity": "sha1-O3oNJiA910s6nfTJz7gnsvuQfmQ=",
       "requires": {
         "lru-cache": "2.5.0"
@@ -4327,7 +4327,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0",
-          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
           "integrity": "sha1-2COIrpyWC+y+oMc7uet5tsbOmus="
         }
       }
@@ -4646,7 +4646,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -4663,7 +4663,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -4761,7 +4761,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -4806,7 +4806,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -5579,7 +5579,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6362,7 +6362,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -6994,7 +6994,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "y18n": {

--- a/src/Commands.re
+++ b/src/Commands.re
@@ -63,10 +63,13 @@ let decodeCommand = text => {
       | "blame" => Blame
       | "classics" => EasterEgg(IteamClassics)
       | "clear" => Clear
+      | "cq"
       | "currentqueue"
+      | "gq"
       | "getqueue" => CurrentQueue
       | "freebird" => EasterEgg(FreeBird)
       | "friday" => EasterEgg(Friday)
+      | "fq"
       | "fullqueue" => FullQueue
       | "help" => Help
       | "l"


### PR DESCRIPTION
Fixes #34 

Add short names to "queue" commands. Most changes in the test file, except the added commands `gq`, `cq` and `fq`, are from removing the wrapping describe