### PR TITLE
feat: add helpful messages if queue is empty

### DIFF
--- a/src/services/Services.re
+++ b/src/services/Services.re
@@ -20,7 +20,7 @@ let nowPlayingData =
       {artist, title, album, position, duration, queuePosition}: Sonos.Decode.currentTrackResponse,
     ) =>
   switch (queuePosition) {
-  | 0. => "Nothing is currently playing, add a track using `search <your track>`"
+  | 0. => Messages.nothingIsPlaying
   | _ =>
     let track =
       Utils.artistAndTitle(~artist, ~title)

--- a/src/utils/Messages.re
+++ b/src/utils/Messages.re
@@ -1,0 +1,3 @@
+let nothingIsPlaying = "Nothing is currently playing, add a track using `search <your track>`";
+
+let emptyQueue = "The queue is empty, add a track using `search <your track>`";


### PR DESCRIPTION
If the queue is empty `getQueue` returns `false` and not an object as expected. Here we handle that case and return helpful messages to the user. We also get rid of the ugly `queue == false` in `play` 😅 

Closes #33