### PR TITLE
feat: add in-depth help message for queue

### DIFF
--- a/__tests__/Utils_test.re
+++ b/__tests__/Utils_test.re
@@ -48,13 +48,20 @@ describe("#parsedTrack", () => {
     |> toEqual("spotify:track:4UQLQJu3DNvVkMVglwElU2")
   );
 
-  test("parses Spotify URL", () =>
+  test("parses spotify url", () =>
     expect(
       parsedTrack(
-        "https://open.spotify.com/track/6DUdjPhPTpE3zMTA9jdCex?si=pufHMXrGTpC89VBP88CAow",
+        "https://open.spotify.com/track/6dudjphptpe3zmta9jdcex?si=pufhmxrgtpc89vbp88caow",
       ),
     )
-    |> toEqual("spotify:track:6DUdjPhPTpE3zMTA9jdCex")
+    |> toEqual("spotify:track:6dudjphptpe3zmta9jdcex")
+  );
+
+  test("parses spotify url", () =>
+    expect(
+      parsedTrack("https://open.spotify.com/track/5fxDE80ZPA32JXjZN87pQJ"),
+    )
+    |> toEqual("spotify:track:5fxDE80ZPA32JXjZN87pQJ")
   );
 });
 

--- a/src/Event.re
+++ b/src/Event.re
@@ -13,8 +13,9 @@ module Log = {
 let make = (~command, ~args, ~user, ()) => {
   Log.make(command, args, user);
 
-  switch (command) {
-  | Decode.Requester.Human(cmd) =>
+  switch (command, args) {
+  | (Decode.Requester.Human(cmd), "help") => Help.make(Some(cmd))
+  | (Decode.Requester.Human(cmd), _) =>
     switch (cmd) {
     | NowPlaying => NowPlaying.run()
     | Search => Spotify.Search.make(args)
@@ -43,7 +44,7 @@ let make = (~command, ~args, ~user, ()) => {
     | MostPlayed => MostPlayed.run()
     | Toplist => Toplist.run()
     | EasterEgg(egg) => EasterEgg.run(egg)
-    | Help => `Ok(Slack.Block.make([`Section(Message.help)])) |> resolve
+    | Help => Help.make(None)
     | Time =>
       `Ok(Slack.Block.make([`Section(Message.thisIsWejay)])) |> resolve
 
@@ -53,6 +54,6 @@ let make = (~command, ~args, ~user, ()) => {
       |> resolve
     | UnhandledCommand => `Failed(Message.unhandledCommand) |> resolve
     }
-  | Bot => resolve(`Failed(Message.botRequest))
+  | (Bot, _) => resolve(`Failed(Message.botRequest))
   };
 };

--- a/src/commands/Help.re
+++ b/src/commands/Help.re
@@ -1,0 +1,23 @@
+module Messages = {
+  let queue = [
+    `Section(
+      {j|The _queue_ command adds a new track to the end of the queue.\nIt's used by copying a *URI* or *URL* of a track from Spotify.|j},
+    ),
+    `Section("*Shorthand version*: q"),
+    `Section("*For example*:"),
+    `Section("`q spotify:track:4abjt5hWugcmJucydd6eHL`"),
+    `Section("`queue https://open.spotify.com/track/5fxDE80ZPA32JXjZN87pQJ`"),
+  ];
+};
+
+let make = cmd => {
+  (
+    switch (cmd) {
+    | Some(Commands.Queue) => Messages.queue
+    | Some(_)
+    | None => [`Section(Message.help)]
+    }
+  )
+  ->(blocks => `Ok(Slack.Block.make(blocks)))
+  ->Js.Promise.resolve;
+};


### PR DESCRIPTION
Closes #65 

Try `q help` to get a longer explanation of the command